### PR TITLE
fix: close the redis connection once callbacks have returned

### DIFF
--- a/lib/redis-model.js
+++ b/lib/redis-model.js
@@ -72,15 +72,18 @@ RedisModel.prototype.set = function (long_url, callback) {
     this.findUrl(long_url, function (err, reply) {
         if (err) {
             callback(500);
+            self.db.quit();
         } else if (reply) {
             callback(null, {
                 'hash'      : reply,
                 'long_url'  : long_url
             });
+            self.db.quit();
         } else {
             self.uniqId(function (err, reply) {
                 if (err) {
                     callback(500);
+                    self.db.quit();
                 } else {
                     var response = {
                         'hash'      : self.b64encode(reply),
@@ -100,6 +103,7 @@ RedisModel.prototype.set = function (long_url, callback) {
                         } else {
                             callback(null, response);
                         }
+                        self.db.quit();
                     });
                 }
             });
@@ -127,5 +131,6 @@ RedisModel.prototype.get = function (short_url, callback, click) {
         } else {
             callback(503);
         }
+        self.db.quit();
     });
 };


### PR DESCRIPTION
Since a new connection is opened on each request through the RedisModel
instanciation, it should be closed once a set or a get is done.

In our own fork we experienced an issue where too many redis connections were opened and never closed. 